### PR TITLE
fix(playlist): increase parameter count and update chunk size calculation

### DIFF
--- a/app/lib/playlist.server.ts
+++ b/app/lib/playlist.server.ts
@@ -4,10 +4,10 @@ import type { AppLoadContext } from "react-router";
 import { playlist, playlistItem, userSettings } from "~/database/schema";
 
 const D1_MAX_BOUND_PARAMETERS = 100;
-const PLAYLIST_ITEM_COLUMN_COUNT = 4;
+const PLAYLIST_ITEM_PARAMETER_COUNT = 5;
 const PLAYLIST_ITEM_CHUNK_SIZE = Math.max(
   1,
-  Math.floor(D1_MAX_BOUND_PARAMETERS / PLAYLIST_ITEM_COLUMN_COUNT),
+  Math.floor(D1_MAX_BOUND_PARAMETERS / PLAYLIST_ITEM_PARAMETER_COUNT),
 );
 
 export interface PlaylistItem {


### PR DESCRIPTION
Updated PLAYLIST_ITEM_COLUMN_COUNT to PLAYLIST_ITEM_PARAMETER_COUNT and increased its value from 4 to 5. This change affects the PLAYLIST_ITEM_CHUNK_SIZE calculation which now uses the new parameter count to determine the optimal chunk size based on D1_MAX_BOUND_PARAMETERS limit. The modification ensures better alignment with database parameter constraints.

## Overview  
<!-- Briefly describe the purpose of this Pull Request. -->

## Changes  

- Change 1  
- Change 2  
- Change 3  

## Related Issue  

- Issue number (e.g., #123)  
